### PR TITLE
Reinitialize repo when injecting new modules

### DIFF
--- a/lib/CPAN/Dark.pm
+++ b/lib/CPAN/Dark.pm
@@ -45,7 +45,10 @@ END_PACKAGE_HEADER
 sub should_create_repository
 {
     my $self = shift;
-    my $reinit = @_ ? shift : $self->{reinitialize};
+    my %args = @_;
+    my $reinit = exists $args{reinitialize}
+        ? $args{reinitialize}
+        : $self->{reinitialize};
 
     my $cpmi = $self->{cpmi};
     my $repo = $cpmi->config->get( 'local' );
@@ -81,7 +84,7 @@ sub inject_files
     # if this is a new version of module already in the darkpan the old version
     # will be listed first in the 02packages file, so reinitialize that file
     # to make sure tools like cpanm only see the latest version
-    $self->create_darkpan(1);
+    $self->create_darkpan(reinitialize => 1);
 
     my $cpmi = $self->{cpmi};
 

--- a/lib/CPAN/Dark.pm
+++ b/lib/CPAN/Dark.pm
@@ -23,7 +23,7 @@ sub create_darkpan
     my $self = shift;
     my $cpmi = $self->{cpmi};
 
-    return unless my $repo = $self->should_create_repository;
+    return unless my $repo = $self->should_create_repository(@_);
 
     File::Path::mkpath( [ dir( $repo, 'authors' ), dir( $repo, 'modules' ) ] );
 
@@ -45,12 +45,14 @@ END_PACKAGE_HEADER
 sub should_create_repository
 {
     my $self = shift;
+    my $reinit = @_ ? shift : $self->{reinitialize};
+
     my $cpmi = $self->{cpmi};
     my $repo = $cpmi->config->get( 'local' );
 
     Carp::croak( "No DarkPAN configured!" ) unless $repo;
 
-    return $repo if $self->{reinitialize};
+    return $repo if $reinit;
 
     return $repo unless -d $repo;
     return $repo unless -f file( $repo, 'authors', '01mailrc.txt.gz' );
@@ -79,9 +81,7 @@ sub inject_files
     # if this is a new version of module already in the darkpan the old version
     # will be listed first in the 02packages file, so reinitialize that file
     # to make sure tools like cpanm only see the latest version
-    $self->{reinitialize} = 1;
-
-    $self->create_darkpan;
+    $self->create_darkpan(1);
 
     my $cpmi = $self->{cpmi};
 

--- a/lib/CPAN/Dark.pm
+++ b/lib/CPAN/Dark.pm
@@ -50,6 +50,8 @@ sub should_create_repository
 
     Carp::croak( "No DarkPAN configured!" ) unless $repo;
 
+    return $repo if $self->{reinitialize};
+
     return $repo unless -d $repo;
     return $repo unless -f file( $repo, 'authors', '01mailrc.txt.gz' );
     return $repo unless -f
@@ -73,6 +75,12 @@ sub write_gz
 sub inject_files
 {
     my $self = shift;
+
+    # if this is a new version of module already in the darkpan the old version
+    # will be listed first in the 02packages file, so reinitialize that file
+    # to make sure tools like cpanm only see the latest version
+    $self->{reinitialize} = 1;
+
     $self->create_darkpan;
 
     my $cpmi = $self->{cpmi};


### PR DESCRIPTION
Reset the 02packages file in case this is a newer version
of a previously injected module to make sure
tools like cpanm only see the latest version.

Since this module uses CPAN::Mini::Inject it suffers from this outstanding issue:
https://github.com/AndyA/CPAN--Mini--Inject/issues/2

When CPAN::Mini::Inject injects a new module it simply adds the module below
any previous instances of that module in 02packages,
and cpanm will stop at the first one.

If we assume that this repo is only a darkpan
then there's no minicpan to call update_mirror and remove old entries.
If this darkpan contains all the modules it should be showing then it doesn't hurt to reinitialize the file.
