### PR TITLE
Add all modules to the DarkPAN, not just the main one.

### DIFF
--- a/lib/CPAN/Dark.pm
+++ b/lib/CPAN/Dark.pm
@@ -82,14 +82,15 @@ sub inject_files
         Carp::croak( "Cannot find '$file'" ) unless $file and -e $file;
 
         my $meta    = $self->load_metayaml( $file );
-        (my $module = $meta->{name}) =~ s/-/::/g;
-
-        $cpmi->add(
-            file     => $file,
-            module   => $module,
-            version  => $meta->{version},
-            authorid => $cpmi->config->{author},
-        );
+        for my $module ( keys %{$meta->{provides}} )
+        {
+            $cpmi->add(
+                file     => $file,
+                module   => $module,
+                authorid => $cpmi->config->{author},
+                version  => $meta->{provides}->{$module}->{version},
+            );
+        }
     }
 
     $cpmi->writelist->inject;


### PR DESCRIPTION
Instead of adding only the "main" module, we add all the
modules that the distro provides.  This is basically what
the Pause indexer would do.

CPAN::Mini::Inject is flawed in this regard.  The add()
method is basically designed to inject distros that contain
only a single module.  But any non-trivial distro will
have several modules.  The mcpani[1] command works around
this limitation by calling the add() method for each
module that the distro provides.  Each call to add() also
copies the *.tar.gz into the repository.  So it ends up
copying the same file over and over.  I think the correct
solution is to change the interface on the add() method
to support multiple module names, which could all have
different version numbers.

I suspect the decision to design CPAN::Mini::Inject is the
result of an old anti-pattern.  Once upon a time, it was
typical for CPAN authors to only declare dependence
on the _main_ module of a distro within their Makefile.PL
or Build.PL script.  For example, my code might say:

use PPI::Document;

but in my Makefile.PL it would say:

requires => { 'PPI' => 0 };

This implies that PPI and PPI::Document will always be in
the same distro.  But you cannot rely on that -- authors
are free to move modules into other distros at any time.
Technically, this would not constitute an interface
change, because the dependency is upon the module, not
the distribution it belongs to.

These days, the correct approach is to list every module
that you C<use> in your code as a dependency.  This
ensures you'll get the physical files that you require,
even if their logical location moves from one distro to
another.
